### PR TITLE
Add mode switch functionality

### DIFF
--- a/api/handlers/mode.go
+++ b/api/handlers/mode.go
@@ -1,21 +1,25 @@
 package handlers
 
 import (
+	"context"
 	"math/rand"
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
+
+	"kiezbox/internal/meshtastic"
 
 	"github.com/gin-gonic/gin"
 )
 
-// @Summary Get current mode
-// @Description Returns the current Kiezbox mode
-// @Tags Mode
-// @Produce json
-// @Success 200 {object} map[string]string
-// @Router /mode [get]
-func Mode(c *gin.Context) {
+// SetModeRequest represents the expected JSON body
+type SetModeRequest struct {
+	Mode int `json:"mode"`
+}
+
+// GetMode fetches the current mode
+func GetMode(c *gin.Context) {
 	// random number for demonstration purposes 1-3
 	var mode int
 	value := os.Getenv("KB_MODE_OVERRIDE")
@@ -32,4 +36,26 @@ func Mode(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"mode": mode, // e.g., "normal", "maintenance"
 	})
+}
+
+// SetMode sets the Kiezbox mode to the provided value
+func SetMode(mts *meshtastic.MTSerial, ctx context.Context, wg *sync.WaitGroup) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Extract the "mode" parameter from the URL
+		modeStr := c.Param("mode")
+		modeInt, err := strconv.Atoi(modeStr)
+		if err != nil || modeInt < 0 || modeInt > 2 {
+			// Respond with error if the mode is not a valid integer
+			c.JSON(400, gin.H{"error": "Invalid mode. Allowed values: 0, 1, 2"})
+			return
+		}
+		mode := int32(modeInt)
+
+		// Build the control message to set the desired mode
+		control := meshtastic.BuildKiezboxControl(nil, &mode)
+		// Set the mode
+		go mts.SetKiezboxValues(ctx, wg, control)
+		// Reply to the client with success
+		c.JSON(http.StatusOK, gin.H{"status": "mode set", "mode": mode})
+	}
 }

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -1,7 +1,10 @@
 package routes
 
 import (
+	"context"
 	"kiezbox/api/handlers"
+	"kiezbox/internal/meshtastic"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 )
@@ -23,11 +26,12 @@ func CORSMiddleware() gin.HandlerFunc {
 	}
 }
 
-func RegisterRoutes(r *gin.Engine) {
+func RegisterRoutes(r *gin.Engine, mts *meshtastic.MTSerial, ctx context.Context, wg *sync.WaitGroup) {
 	// Register the hello world route
 	r.Use(CORSMiddleware())
-	r.GET("/mode", handlers.Mode)
+	r.GET("/mode", handlers.GetMode)
 	r.Any("/session", handlers.Session)
 	r.GET("/sipconfig", handlers.SIPConfig)
 	r.POST("/asterisk/:pstype/:singlemulti", handlers.Asterisk)
+	r.POST("/mode/:mode", handlers.SetMode(mts, ctx, wg))
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/mock"
 	"github.com/tarm/serial"
 
@@ -79,7 +80,7 @@ func (m *MockMTSerial) ConfigWriter(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Done()
 }
 
-func (m *MockMTSerial) APIHandler(ctx context.Context, wg *sync.WaitGroup) {
+func (m *MockMTSerial) APIHandler(ctx context.Context, wg *sync.WaitGroup, r *gin.Engine) {
 	m.Called(ctx, wg)
 	wg.Done()
 }
@@ -99,7 +100,7 @@ func TestRunGoroutines(t *testing.T) {
 	mockMTSerial.On("SetKiezboxValues", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("GetConfig", mock.Anything, mock.Anything, time.Duration(30*time.Second)).Return(nil)
 	mockMTSerial.On("ConfigWriter", mock.Anything, mock.Anything).Return(nil)
-	mockMTSerial.On("APIHandler", mock.Anything, mock.Anything).Return(nil)
+	mockMTSerial.On("APIHandler", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	portFactory := func(conf *serial.Config) (meshtastic.SerialPort, error) {
 		return mockMTSerial, nil
@@ -137,7 +138,7 @@ func TestRunGoroutines(t *testing.T) {
 	mockMTSerial.AssertCalled(t, "SetKiezboxValues", mock.Anything, mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "GetConfig", mock.Anything, mock.Anything, time.Duration(30*time.Second))
 	mockMTSerial.AssertCalled(t, "ConfigWriter", mock.Anything, mock.Anything)
-	mockMTSerial.AssertCalled(t, "APIHandler", mock.Anything, mock.Anything)
+	mockMTSerial.AssertCalled(t, "APIHandler", mock.Anything, mock.Anything, mock.Anything)
 
 	// Wait for all goroutines to finish
 	wg.Wait()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tarm/serial"
 
 	"kiezbox/internal/db"
+	"kiezbox/internal/github.com/meshtastic/go/generated"
 	"kiezbox/internal/meshtastic"
 )
 
@@ -63,8 +64,8 @@ func (m *MockMTSerial) DBRetry(ctx context.Context, wg *sync.WaitGroup, db_clien
 	wg.Done()
 }
 
-func (m *MockMTSerial) Settime(ctx context.Context, wg *sync.WaitGroup, time int64) {
-	m.Called(ctx, wg, time)
+func (m *MockMTSerial) SetKiezboxValues(ctx context.Context, wg *sync.WaitGroup, control *generated.KiezboxMessage_Control) {
+	m.Called(ctx, wg, control)
 	wg.Done()
 }
 
@@ -95,7 +96,7 @@ func TestRunGoroutines(t *testing.T) {
 	mockMTSerial.On("MessageHandler", mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("DBWriter", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("DBRetry", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockMTSerial.On("Settime", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMTSerial.On("SetKiezboxValues", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("GetConfig", mock.Anything, mock.Anything, time.Duration(30*time.Second)).Return(nil)
 	mockMTSerial.On("ConfigWriter", mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("APIHandler", mock.Anything, mock.Anything).Return(nil)
@@ -133,7 +134,7 @@ func TestRunGoroutines(t *testing.T) {
 	mockMTSerial.AssertCalled(t, "MessageHandler", mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "DBWriter", mock.Anything, mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "DBRetry", mock.Anything, mock.Anything, mock.Anything)
-	mockMTSerial.AssertCalled(t, "Settime", mock.Anything, mock.Anything, mock.Anything)
+	mockMTSerial.AssertCalled(t, "SetKiezboxValues", mock.Anything, mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "GetConfig", mock.Anything, mock.Anything, time.Duration(30*time.Second))
 	mockMTSerial.AssertCalled(t, "ConfigWriter", mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "APIHandler", mock.Anything, mock.Anything)

--- a/internal/meshtastic/serial.go
+++ b/internal/meshtastic/serial.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tarm/serial"
 	"google.golang.org/protobuf/proto"
 
-	"kiezbox/api/routes"
 	"kiezbox/internal/db"
 	"kiezbox/internal/github.com/meshtastic/go/generated"
 )
@@ -596,15 +595,9 @@ func (mts *MTSerial) ConfigWriter(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 // APIHandler starts the API for the Kiezbox Gateway Service.
-func (mts *MTSerial) APIHandler(ctx context.Context, wg *sync.WaitGroup) {
+func (mts *MTSerial) APIHandler(ctx context.Context, wg *sync.WaitGroup, r *gin.Engine) {
 	// Decrement WaitGroup when function exits
 	defer wg.Done()
-
-	// Create a new Gin router
-	r := gin.Default()
-
-	// Register API routes
-	routes.RegisterRoutes(r)
 
 	// Configure the HTTP server
 	server := &http.Server{

--- a/internal/meshtastic/serial.go
+++ b/internal/meshtastic/serial.go
@@ -173,7 +173,7 @@ func (mts *MTSerial) SetKiezboxValues(ctx context.Context, wg *sync.WaitGroup, c
 	// Marshal the Kiezbox message
 	kiezboxData, err := proto.Marshal(kiezboxMessage)
 	if err != nil {
-		log.Printf("Failed to marshal KiezboxMessage: %v", err)
+		slog.Error("Failed to marshal KiezboxMessage", "err", err)
 	}
 
 	// Create the Data message
@@ -199,7 +199,7 @@ func (mts *MTSerial) SetKiezboxValues(ctx context.Context, wg *sync.WaitGroup, c
 		},
 	}
 
-	log.Printf("Setting Kiezbox values: %+v\n", control)
+	slog.Info("Setting Kiezbox values: %+v\n", control)
 
 	// Check if the context has been canceled before attempting to write
 	select {


### PR DESCRIPTION
Unittests are currently failing due to mismatching types for the device argument in  `RegisteringRoutes()` (`meshtastic.MTSerial` vs. `MeshtasticDevice`). I have to think about our mocking strategy a little bit and fix it.

With the real device, it seems to work alright, but further testing wouldn't hurt, especially checking that the device is indeed changing modes. I can see that the KiezboxMessage for changing the mode is correctly sent.

I also should rebase and fix conflicts after merging the last PR from Jan (related to config), if there are any.