### PR TITLE
Bugfix: main_test.go unittest failing after last changes in SetKiezboxControlValue

### DIFF
--- a/api/handlers/admin_control.go
+++ b/api/handlers/admin_control.go
@@ -11,7 +11,7 @@ import (
 )
 
 // SetKiezboxControlValue sets a Kiezbox control value based on the provided key and value
-func SetKiezboxControlValue(mts *meshtastic.MTSerial, ctx context.Context, wg *sync.WaitGroup) gin.HandlerFunc {
+func SetKiezboxControlValue(device meshtastic.MeshtasticDevice, ctx context.Context, wg *sync.WaitGroup) gin.HandlerFunc {
 	return func(ginCtx *gin.Context) {
 		// Extract key and value parameters from the query string
 		key := ginCtx.PostForm("key")
@@ -29,7 +29,7 @@ func SetKiezboxControlValue(mts *meshtastic.MTSerial, ctx context.Context, wg *s
 		}
 
 		// Set the control value
-		go mts.SetKiezboxControlValue(ctx, wg, control)
+		go device.SetKiezboxControlValue(ctx, wg, control)
 		// Reply to the client with success
 		ginCtx.JSON(http.StatusOK, gin.H{"status": "control value set", "key": key, "value": value})
 	}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -27,7 +27,7 @@ func CORSMiddleware() gin.HandlerFunc {
 	}
 }
 
-func RegisterRoutes(r *gin.Engine, mts *meshtastic.MTSerial, ctx context.Context, wg *sync.WaitGroup) {
+func RegisterRoutes(r *gin.Engine, device meshtastic.MeshtasticDevice, ctx context.Context, wg *sync.WaitGroup) {
 	// Use Corse middlewar only for local testing
 	if cfg.Cfg.CorsLocalhost {
 		r.Use(CORSMiddleware())
@@ -36,5 +36,5 @@ func RegisterRoutes(r *gin.Engine, mts *meshtastic.MTSerial, ctx context.Context
 	r.GET("/info", handlers.Info)
 	r.Any("/session", handlers.Session)
 	r.POST("/asterisk/:pstype/:singlemulti", handlers.Asterisk)
-	r.POST("/admin/control", handlers.SetKiezboxControlValue(mts, ctx, wg))
+	r.POST("/admin/control", handlers.SetKiezboxControlValue(device, ctx, wg))
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -66,7 +66,7 @@ func (m *MockMTSerial) DBRetry(ctx context.Context, wg *sync.WaitGroup, db_clien
 	wg.Done()
 }
 
-func (m *MockMTSerial) SetKiezboxValues(ctx context.Context, wg *sync.WaitGroup, control *generated.KiezboxMessage_Control) {
+func (m *MockMTSerial) SetKiezboxControlValue(ctx context.Context, wg *sync.WaitGroup, control *generated.KiezboxMessage_Control) {
 	m.Called(ctx, wg, control)
 	wg.Done()
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -102,7 +102,7 @@ func TestRunGoroutines(t *testing.T) {
 	mockMTSerial.On("DBWriter", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("DBRetry", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("SetKiezboxControlValue", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockMTSerial.On("GetConfig", mock.Anything, mock.Anything, time.Duration(30*time.Second)).Return(nil)
+	mockMTSerial.On("GetConfig", mock.Anything, mock.Anything, time.Duration(15*time.Second)).Return(nil)
 	mockMTSerial.On("ConfigWriter", mock.Anything, mock.Anything).Return(nil)
 	mockMTSerial.On("APIHandler", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -137,7 +137,7 @@ func TestRunGoroutines(t *testing.T) {
 	mockMTSerial.AssertCalled(t, "DBWriter", mock.Anything, mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "DBRetry", mock.Anything, mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "SetKiezboxControlValue", mock.Anything, mock.Anything, mock.Anything)
-	mockMTSerial.AssertCalled(t, "GetConfig", mock.Anything, mock.Anything, time.Duration(30*time.Second))
+	mockMTSerial.AssertCalled(t, "GetConfig", mock.Anything, mock.Anything, time.Duration(15*time.Second))
 	mockMTSerial.AssertCalled(t, "ConfigWriter", mock.Anything, mock.Anything)
 	mockMTSerial.AssertCalled(t, "APIHandler", mock.Anything, mock.Anything, mock.Anything)
 

--- a/internal/meshtastic/serial.go
+++ b/internal/meshtastic/serial.go
@@ -60,6 +60,21 @@ type MTSerial struct {
 	portFactory PortFactory
 }
 
+// Using an interface as an intermediate layer instead of calling the meshtastic functions directly
+// allows for dependency injection, essential for unittesting
+type MeshtasticDevice interface {
+	Writer(ctx context.Context, wg *sync.WaitGroup)
+	Heartbeat(ctx context.Context, wg *sync.WaitGroup, interval time.Duration)
+	Reader(ctx context.Context, wg *sync.WaitGroup)
+	MessageHandler(ctx context.Context, wg *sync.WaitGroup)
+	DBWriter(ctx context.Context, wg *sync.WaitGroup, db_client *db.InfluxDB)
+	DBRetry(ctx context.Context, wg *sync.WaitGroup, db_client *db.InfluxDB)
+	SetKiezboxControlValue(ctx context.Context, wg *sync.WaitGroup, control *generated.KiezboxMessage_Control)
+	GetConfig(ctx context.Context, wg *sync.WaitGroup, interval time.Duration)
+	ConfigWriter(ctx context.Context, wg *sync.WaitGroup)
+	APIHandler(ctx context.Context, wg *sync.WaitGroup, r *gin.Engine)
+}
+
 func interfaceIsNil(i interface{}) bool {
 	return i == nil || (reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil())
 }


### PR DESCRIPTION
Reasons for the failed test were:

- Wrong name in `SetKiezboxControlValue` mock
- We were checking for a real `MTSerial` instance instead of its interface when running  in `SetKiezboxControlValue` in `main.go`. In order to be able to import the interface from the test, I moved it to the `meshtastic` package. This also made the `main.go` file a bit cleaner.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210590715156643